### PR TITLE
Fix duplicate Product entries in Android CommerceEvents

### DIFF
--- a/Library/mParticle.Xamarin.Android/MParticleSDKImpl.cs
+++ b/Library/mParticle.Xamarin.Android/MParticleSDKImpl.cs
@@ -37,14 +37,26 @@ namespace mParticle.Xamarin
             Android.CommerceBinding.CommerceEvent.Builder bindingCommerceEventBuilder = null;
 
             if (commerceEvent.ProductAction > 0 && commerceEvent.Products != null && commerceEvent.Products.Length > 0)
+            {
                 bindingCommerceEventBuilder = new Android.CommerceBinding.CommerceEvent.Builder(Utils.ConvertToMpProductAction(commerceEvent.ProductAction), Utils.ConvertToMpProduct(commerceEvent.Products[0]));
-
+                var temp = new List<Product>(commerceEvent.Products);
+                temp.RemoveAt(0);
+                commerceEvent.Products = temp.ToArray();
+            }
             else if (commerceEvent.Promotions != null && commerceEvent.Promotions.Length > 0)
+            {
                 bindingCommerceEventBuilder = new Android.CommerceBinding.CommerceEvent.Builder(Utils.ConvertToMpPromotionAction(commerceEvent.PromotionAction), Utils.ConvertToMpPromotion(commerceEvent.Promotions[0]));
-
+                var temp = new List<Promotion>(commerceEvent.Promotions);
+                temp.RemoveAt(0);
+                commerceEvent.Promotions = temp.ToArray();
+            }
             else
+            {
                 bindingCommerceEventBuilder = new Android.CommerceBinding.CommerceEvent.Builder(Utils.ConvertToMpImpression(commerceEvent.Impressions[0]));
-
+                var temp = new List<Impression>(commerceEvent.Impressions);
+                temp.RemoveAt(0);
+                commerceEvent.Impressions = temp.ToArray();
+            }
 
             if (bindingCommerceEventBuilder == null)
                 return;


### PR DESCRIPTION
# Summary
Fix the problem where Products (and Impression and Promotions) where being added twice when they aligned with the productAction/promotionAction/impression(1st)

This bug should be pretty obvious when you look at the fix; we were adding the 0th index item that aligned with the constructor, but then later looping through all the items and adding them individually. This meant that the 0th index item would be added twice.

The fix here was to remove the 0th item after we add it the first time, then proceed as normal
